### PR TITLE
get_geometry returns a non-None value

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -369,8 +369,11 @@ impl WlcView {
     }
 
     /// Gets the geometry of the view.
-    pub fn get_geometry(&self) -> Option<&Geometry> {
-        None
+    pub fn get_geometry(&self) -> Option<Geometry> {
+        Some(Geometry {
+            origin: Point { x: 0, y: 0},
+            size:   Size  { w: 0, h: 0}
+        })
     }
 
     /// Gets the geometry of the view (that wlc displays).


### PR DESCRIPTION
To aid in testing, it would be very beneficial if `get_geometry` on `WlcView` returned a simple value, such as a zero point.